### PR TITLE
Removed Spigot API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/
+.idea
+Polizeibot.iml
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -24,29 +24,30 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>4.1.1_127</version>
+            <version>4.1.1_136</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.8.8-R0.1-SNAPSHOT</version>
-            <scope>compile</scope>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.21</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <repositories>
         <repository>
             <id>jcenter</id>
             <name>jcenter-bintray</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
-        </repository>
-        <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
     </repositories>
 

--- a/src/main/java/de/demokratie/polizeibot/Bot.java
+++ b/src/main/java/de/demokratie/polizeibot/Bot.java
@@ -69,6 +69,7 @@ public class Bot {
             try {
                 Thread.sleep(100);
             } catch (InterruptedException e) {
+                e.printStackTrace();
             }
 
             while (true) {
@@ -82,9 +83,9 @@ public class Bot {
 
                         Date expiration = mute.getExpireDate();
                         Date now = Date.from(Instant.now());
-
+                        //System.out.println("a" + expiration.getTime());
+                        //System.out.println("b" + now.getTime());
                         if (now.after(expiration)) {
-
                             guild.removeRoleFromMember(mute.getMember(), guild.getRolesByName("Mute", true).get(0)).queue();
                             guild.removeRoleFromMember(mute.getMember(), guild.getRolesByName("Voicemute", true).get(0)).queue();
                             guild.removeRoleFromMember(mute.getMember(), guild.getRolesByName("Chatmute", true).get(0)).queue();
@@ -96,6 +97,7 @@ public class Bot {
                 try {
                     Thread.sleep(1000);
                 } catch (InterruptedException e) {
+                    e.printStackTrace();
                 }
             }
         }).start();

--- a/src/main/java/de/demokratie/polizeibot/commands/MuteCommand.java
+++ b/src/main/java/de/demokratie/polizeibot/commands/MuteCommand.java
@@ -3,6 +3,7 @@ package de.demokratie.polizeibot.commands;
 import de.demokratie.polizeibot.Bot;
 import de.demokratie.polizeibot.command.Command;
 import de.demokratie.polizeibot.embed.EmbedCreator;
+import de.demokratie.polizeibot.utils.MuteType;
 import de.demokratie.polizeibot.utils.Utils;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
@@ -10,6 +11,7 @@ import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import java.awt.*;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 public class MuteCommand implements Command {
@@ -61,7 +63,7 @@ public class MuteCommand implements Command {
             target = mentioned.get(0);
         }
         String reason = String.join(" ", Arrays.copyOfRange(args, 2, args.length));
-        Utils.mute(event, target, reason, args[1].toUpperCase());
+        Utils.mute(event, target, reason, Objects.requireNonNull(MuteType.getType(args[1])));
 
         target.getUser().openPrivateChannel().complete().sendMessage(
                 new EmbedCreator(Color.RED)

--- a/src/main/java/de/demokratie/polizeibot/commands/TempMuteCommand.java
+++ b/src/main/java/de/demokratie/polizeibot/commands/TempMuteCommand.java
@@ -3,6 +3,7 @@ package de.demokratie.polizeibot.commands;
 import de.demokratie.polizeibot.Bot;
 import de.demokratie.polizeibot.command.Command;
 import de.demokratie.polizeibot.embed.EmbedCreator;
+import de.demokratie.polizeibot.utils.MuteType;
 import de.demokratie.polizeibot.utils.Utils;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
@@ -12,6 +13,7 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 public class TempMuteCommand implements Command {
@@ -69,7 +71,7 @@ public class TempMuteCommand implements Command {
         try {
             days = Integer.parseInt(args[2]);
         } catch (Exception ex) {
-            Date date = Utils.tempMute(event, target, reason, args[2], args[1].toUpperCase());
+            Date date = Utils.tempMute(event, target, reason, args[2], Objects.requireNonNull(MuteType.getType(args[1])));
             if (date != null) {
 
                 target.getUser().openPrivateChannel().complete().sendMessage(
@@ -92,7 +94,7 @@ public class TempMuteCommand implements Command {
             return;
         }
 
-        Date date = Utils.tempMute(event, target, reason, days, args[1].toUpperCase());
+        Date date = Utils.tempMute(event, target, reason, days, Objects.requireNonNull(MuteType.getType(args[1])));
 
         target.getUser().openPrivateChannel().complete().sendMessage(
                 new EmbedCreator(Color.RED)

--- a/src/main/java/de/demokratie/polizeibot/listener/JoinListener.java
+++ b/src/main/java/de/demokratie/polizeibot/listener/JoinListener.java
@@ -18,13 +18,13 @@ public class JoinListener extends ListenerAdapter {
         Information info = Utils.getInformation(m);
         if(info.isMuted()) {
             switch(info.getMute().getType()) {
-                case "GENERAL":
+                case GENERAL:
                     guild.addRoleToMember(m, guild.getRolesByName("Mute", true).get(0)).queue();
                     break;
-                case "VOICE":
+                case VOICE:
                     guild.addRoleToMember(m, guild.getRolesByName("Voicemute", true).get(0)).queue();
                     break;
-                case "CHAT":
+                case CHAT:
                     guild.addRoleToMember(m, guild.getRolesByName("Chatmute", true).get(0)).queue();
                     break;
             }

--- a/src/main/java/de/demokratie/polizeibot/objects/Mute.java
+++ b/src/main/java/de/demokratie/polizeibot/objects/Mute.java
@@ -1,26 +1,32 @@
 package de.demokratie.polizeibot.objects;
 
+import de.demokratie.polizeibot.utils.MuteType;
 import net.dv8tion.jda.api.entities.Member;
+import org.yaml.snakeyaml.Yaml;
 
+import java.io.File;
+import java.io.InputStream;
+import java.rmi.UnexpectedException;
 import java.util.Date;
+import java.util.Map;
 
 public class Mute {
 
     private boolean muted;
 
     private String reason;
-    private String type;
+    private MuteType type;
     private Member m;
     private Member muter;
     private Date d;
     private Date expireDate;
     private boolean permanent;
 
-    public String getType() {
+    public MuteType getType() {
         return type;
     }
 
-    public void setType(String type) {
+    public void setType(MuteType type) {
         this.type = type;
     }
 

--- a/src/main/java/de/demokratie/polizeibot/objects/SimpleMute.java
+++ b/src/main/java/de/demokratie/polizeibot/objects/SimpleMute.java
@@ -1,0 +1,77 @@
+package de.demokratie.polizeibot.objects;
+
+public class SimpleMute {
+    private boolean muted;
+
+    private String reason;
+    private String type;
+    private String member;
+    private String muter;
+    private long date;
+    private long expireDate;
+    private boolean permanent;
+
+    public boolean getMuted() {
+        return muted;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getMember() {
+        return member;
+    }
+
+    public String getMuter() {
+        return muter;
+    }
+
+    public long getDate() {
+        return date;
+    }
+
+    public long getExpireDate() {
+        return expireDate;
+    }
+
+    public boolean getPermanent() {
+        return permanent;
+    }
+
+    public void setMuted(boolean muted) {
+        this.muted = muted;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public void setMember(String member) {
+        this.member = member;
+    }
+
+    public void setMuter(String muter) {
+        this.muter = muter;
+    }
+
+    public void setDate(long date) {
+        this.date = date;
+    }
+
+    public void setExpireDate(long expireDate) {
+        this.expireDate = expireDate;
+    }
+
+    public void setPermanent(boolean permanent) {
+        this.permanent = permanent;
+    }
+}

--- a/src/main/java/de/demokratie/polizeibot/objects/SimpleWarn.java
+++ b/src/main/java/de/demokratie/polizeibot/objects/SimpleWarn.java
@@ -1,0 +1,34 @@
+package de.demokratie.polizeibot.objects;
+
+public class SimpleWarn {
+    private String reason;
+    private String warner;
+    private long date;
+
+    public SimpleWarn() {
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public String getWarner() {
+        return warner;
+    }
+
+    public long getDate() {
+        return date;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+    public void setWarner(String warner) {
+        this.warner = warner;
+    }
+
+    public void setDate(long date) {
+        this.date = date;
+    }
+}

--- a/src/main/java/de/demokratie/polizeibot/objects/SimpleWarnList.java
+++ b/src/main/java/de/demokratie/polizeibot/objects/SimpleWarnList.java
@@ -1,0 +1,19 @@
+package de.demokratie.polizeibot.objects;
+
+import java.util.List;
+
+public class SimpleWarnList {
+    private List<SimpleWarn> warns;
+
+    public SimpleWarnList() {
+
+    }
+
+    public List<SimpleWarn> getWarns() {
+        return warns;
+    }
+
+    public void setWarns(List<SimpleWarn> warns) {
+        this.warns = warns;
+    }
+}

--- a/src/main/java/de/demokratie/polizeibot/objects/Warn.java
+++ b/src/main/java/de/demokratie/polizeibot/objects/Warn.java
@@ -7,13 +7,11 @@ import java.util.Date;
 public class Warn {
 
     private String reason;
-    private Member m;
     private Member warner;
     private Date d;
 
-    public Warn(String reason, Member m, Member warner, Date d) {
+    public Warn(String reason, Member warner, Date d) {
         this.reason = reason;
-        this.m = m;
         this.warner = warner;
         this.d = d;
     }
@@ -23,10 +21,6 @@ public class Warn {
 
     public Date getDate() {
         return d;
-    }
-
-    public Member getMember() {
-        return m;
     }
 
     public Member getWarner() {
@@ -39,10 +33,6 @@ public class Warn {
 
     public void setDate(Date d) {
         this.d = d;
-    }
-
-    public void setMember(Member m) {
-        this.m = m;
     }
 
     public void setWarner(Member warner) {

--- a/src/main/java/de/demokratie/polizeibot/utils/ConfigUtils.java
+++ b/src/main/java/de/demokratie/polizeibot/utils/ConfigUtils.java
@@ -1,0 +1,36 @@
+package de.demokratie.polizeibot.utils;
+
+import de.demokratie.polizeibot.objects.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.*;
+import java.rmi.UnexpectedException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ConfigUtils {
+
+    private ConfigUtils() {
+    }
+
+    public static void serialize(@NotNull Object o, @NotNull String path) throws IOException {
+        Yaml yaml = new Yaml();
+        File file = new File(path);
+        if(!file.exists()) {
+            file.getParentFile().mkdirs();
+            file.createNewFile();
+        }
+        yaml.dump(o, new FileWriter(file));
+    }
+
+
+    public static @Nullable Object deserialize(@NotNull String path) throws FileNotFoundException {
+        Yaml yaml = new Yaml();
+        File file = new File(path);
+        if(!file.exists()) return null;
+        InputStream inputStream = new FileInputStream(file);
+        return yaml.load(inputStream);
+    }
+}

--- a/src/main/java/de/demokratie/polizeibot/utils/MuteType.java
+++ b/src/main/java/de/demokratie/polizeibot/utils/MuteType.java
@@ -1,0 +1,35 @@
+package de.demokratie.polizeibot.utils;
+
+public enum MuteType {
+    GENERAL(new String[]{
+            "general",
+            "g"
+    }), CHAT(new String[]{
+            "chat",
+            "c"
+    }), VOICE(new String[]{
+            "voice",
+            "v"
+    });
+
+    String[] names;
+
+    MuteType(String[] names) {
+        this.names = names;
+    }
+
+    public static MuteType getType(String s) {
+        s = s.toLowerCase().trim();
+        for(MuteType type : MuteType.values()) {
+            for(String s1 : type.names) {
+                if(s1.equalsIgnoreCase(s)) return type;
+            }
+        }
+        return null;
+    }
+
+    public String getName() {
+        if(names.length < 1) return this.name().toLowerCase();
+        return names[0];
+    }
+}

--- a/src/main/java/de/demokratie/polizeibot/utils/Utils.java
+++ b/src/main/java/de/demokratie/polizeibot/utils/Utils.java
@@ -3,16 +3,14 @@ package de.demokratie.polizeibot.utils;
 import de.demokratie.polizeibot.Bot;
 import de.demokratie.polizeibot.date.DateUtil;
 import de.demokratie.polizeibot.embed.EmbedCreator;
-import de.demokratie.polizeibot.objects.Information;
-import de.demokratie.polizeibot.objects.Mute;
-import de.demokratie.polizeibot.objects.Warn;
+import de.demokratie.polizeibot.objects.*;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
-import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.awt.*;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -22,109 +20,91 @@ import java.util.List;
 
 public class Utils {
 
+    /**
+     * @param m the {@link Member} who gets warned
+     * @param reason the reason
+     * @param warner the {@link Member} who executed the warn
+     * @return always -1
+     */
     public static int warn(Member m, String reason, Member warner) {
+        SimpleWarnList simpleWarnList = new SimpleWarnList();
+        List<SimpleWarn> simpleWarns = new ArrayList<>();
+        simpleWarnList.setWarns(simpleWarns);
+        SimpleWarn warn = new SimpleWarn();
+        warn.setWarner(warner.getId());
+        warn.setReason(reason);
+        warn.setDate(System.currentTimeMillis());
+        simpleWarns.add(warn);
+        List<Warn> warns = getWarns(m);
+        for(Warn w : warns) {
+            SimpleWarn sw = new SimpleWarn();
+            sw.setDate(w.getDate().getTime());
+            sw.setReason(w.getReason());
+            sw.setWarner(w.getWarner().getId());
+            simpleWarns.add(sw);
+        }
         try {
-            File d = new File("users/" + m.getId() + "/");
-            File f = new File("users/" + m.getId() + "/warns.yml");
-            if (!d.exists()) {
-                d.mkdirs();
-            }
-            if (!f.exists()) {
-                f.createNewFile();
-            }
-
-            YamlConfiguration c = YamlConfiguration.loadConfiguration(f);
-            int warns = c.getInt("warns");
-            c.set("warns", ++warns);
-
-            List<String> reasons = c.getStringList("reasons");
-            reasons.add(reason);
-            c.set("reasons", reasons);
-            c.set(reason.replace(".", "-") + ".warner", warner.getId());
-            c.set(reason.replace(".", "-") + ".date", System.currentTimeMillis());
-            c.save(f);
-
-            return warns;
-
+            ConfigUtils.serialize(simpleWarnList, "users/" + m.getId() + "/warns.yml");
         } catch (IOException e) {
             e.printStackTrace();
         }
-        return 0;
+        return -1;
     }
 
-    public static void mute(GuildMessageReceivedEvent e, Member m, String reason, String TYPE) {
+    public static void mute(GuildMessageReceivedEvent e, Member m, String reason, MuteType type) {
         try {
-            switch(TYPE) {
-                case "GENERAL":
+            switch (type) {
+                case GENERAL:
                     e.getGuild().addRoleToMember(m, e.getGuild().getRolesByName("Mute", true).get(0)).queue();
                     break;
-                case "VOICE":
+                case VOICE:
                     e.getGuild().addRoleToMember(m, e.getGuild().getRolesByName("Voicemute", true).get(0)).queue();
                     break;
-                case "CHAT":
+                case CHAT:
                     e.getGuild().addRoleToMember(m, e.getGuild().getRolesByName("Chatmute", true).get(0)).queue();
                     break;
             }
-            File d = new File("users/" + m.getId() + "/");
-            File f = new File("users/" + m.getId() + "/mutes.yml");
-            if(!d.exists()) {
-                d.mkdirs();
-            }
-            if (!f.exists()) {
-                f.createNewFile();
-            }
-            YamlConfiguration c = YamlConfiguration.loadConfiguration(f);
 
-            c.set("muted", true);
-            c.set("reason", reason);
-            c.set("type", TYPE);
-            c.set("date", System.currentTimeMillis());
-            c.set("muter", e.getMember().getId());
-            c.set("permanent", true);
-            c.save(f);
-        } catch(IOException exc) {
+            SimpleMute mute = new SimpleMute();
+            mute.setMuted(true);
+            mute.setReason(reason);
+            mute.setType(type.getName());
+            mute.setDate(System.currentTimeMillis());
+            mute.setMuter(e.getMember().getId());
+            mute.setPermanent(true);
+            ConfigUtils.serialize(mute, "users/" + m.getId() + "/mutes.yml");
+        } catch (IOException exc) {
             exc.printStackTrace();
         }
     }
 
-    public static Date tempMute(GuildMessageReceivedEvent e, Member m, String reason, int days, String TYPE) {
+    public static Date tempMute(GuildMessageReceivedEvent e, Member m, String reason, int days, MuteType type) {
         try {
-            switch (TYPE) {
-                case "GENERAL":
+            switch (type) {
+                case GENERAL:
                     e.getGuild().addRoleToMember(m, e.getGuild().getRolesByName("Mute", true).get(0)).queue();
                     break;
-                case "VOICE":
+                case VOICE:
                     e.getGuild().addRoleToMember(m, e.getGuild().getRolesByName("Voicemute", true).get(0)).queue();
                     break;
-                case "CHAT":
+                case CHAT:
                     e.getGuild().addRoleToMember(m, e.getGuild().getRolesByName("Chatmute", true).get(0)).queue();
                     break;
             }
-            File d = new File("users/" + m.getId() + "/");
-            File f = new File("users/" + m.getId() + "/mutes.yml");
-            if(!d.exists()) {
-                d.mkdirs();
-            }
-            if (!f.exists()) {
-                f.createNewFile();
-            }
-            YamlConfiguration c = YamlConfiguration.loadConfiguration(f);
-
-            c.set("muted", true);
-            c.set("reason", reason);
-            c.set("type", TYPE);
-            c.set("date", System.currentTimeMillis());
-            c.set("muter", e.getMember().getId());
-            c.set("permanent", false);
+            SimpleMute mute = new SimpleMute();
+            mute.setMuted(true);
+            mute.setReason(reason);
+            mute.setType(type.getName());
+            mute.setDate(System.currentTimeMillis());
+            mute.setMuter(e.getMember().getId());
+            mute.setPermanent(false);
             Date expireDate = new Date();
             Calendar calendar = Calendar.getInstance();
             calendar.setTime(expireDate);
             calendar.add(Calendar.DATE, days);
             expireDate = calendar.getTime();
-            c.set("expireDate", expireDate.getTime());
-            c.save(f);
-            File file = new File("tempmutes.yml");
-            YamlConfiguration cfg = YamlConfiguration.loadConfiguration(file);
+            mute.setExpireDate(expireDate.getTime());
+            ConfigUtils.serialize(mute, "users/" + m.getId() + "/mutes.yml");
             return expireDate;
         } catch (IOException exc) {
             exc.printStackTrace();
@@ -132,16 +112,16 @@ public class Utils {
         return null;
     }
 
-    public static Date tempMute(GuildMessageReceivedEvent e, Member m, String reason, String until, String TYPE) {
+    public static Date tempMute(GuildMessageReceivedEvent e, Member m, String reason, String until, MuteType type) {
         try {
-            switch (TYPE) {
-                case "GENERAL":
+            switch (type) {
+                case GENERAL:
                     e.getGuild().addRoleToMember(m, e.getGuild().getRolesByName("Mute", true).get(0)).queue();
                     break;
-                case "VOICE":
+                case VOICE:
                     e.getGuild().addRoleToMember(m, e.getGuild().getRolesByName("Voicemute", true).get(0)).queue();
                     break;
-                case "CHAT":
+                case CHAT:
                     e.getGuild().addRoleToMember(m, e.getGuild().getRolesByName("Chatmute", true).get(0)).queue();
                     break;
             }
@@ -153,15 +133,13 @@ public class Utils {
             if (!f.exists()) {
                 f.createNewFile();
             }
-            YamlConfiguration c = YamlConfiguration.loadConfiguration(f);
-
-            c.set("muted", true);
-            c.set("reason", reason);
-            c.set("type", TYPE);
-            c.set("date", System.currentTimeMillis());
-            c.set("muter", e.getMember().getId());
-            c.set("permanent", false);
-
+            SimpleMute mute = new SimpleMute();
+            mute.setMuted(true);
+            mute.setReason(reason);
+            mute.setType(type.getName());
+            mute.setDate(System.currentTimeMillis());
+            mute.setMuter(e.getMember().getId());
+            mute.setPermanent(false);
             Date expireDate = null;
             try {
                 expireDate = DateUtil.parse(until);
@@ -169,14 +147,10 @@ public class Utils {
                 e.getChannel().sendMessage(new EmbedCreator(Color.RED).setDescription("Bitte nutze ein Datum mit folgender Syntax: ```\n" +
                         "dd.MM.yyyy-HH:mm:ss oder\n" +
                         "dd.MM.yyyy```").build()).queue();
-                expireDate = new Date();
                 return null;
             }
-
-            c.set("expireDate", expireDate.getTime());
-            c.save(f);
-            File file = new File("tempmutes.yml");
-            YamlConfiguration cfg = YamlConfiguration.loadConfiguration(file);
+            mute.setExpireDate(expireDate.getTime());
+            ConfigUtils.serialize(mute, "users/" + m.getId() + "/mutes.yml");
             return expireDate;
         } catch (IOException exc) {
             exc.printStackTrace();
@@ -186,6 +160,7 @@ public class Utils {
 
     public static List<Warn> getWarns(Member m) {
         List<Warn> warns = new ArrayList<>();
+        /*
         File f = new File("users/" + m.getId() + "/warns.yml");
         if (f.exists()) {
             YamlConfiguration c = YamlConfiguration.loadConfiguration(f);
@@ -206,28 +181,51 @@ public class Utils {
         }
         else {
             return warns;
+        }*/
+        File f = new File("users/" + m.getId() + "/warns.yml");
+        if (f.exists()) {
+            try {
+                SimpleWarnList list = (SimpleWarnList) ConfigUtils.deserialize("users/" + m.getId() + "/warns.yml");
+                Guild guild = m.getGuild();
+                if (list != null)
+                    for (SimpleWarn sWarn : list.getWarns()) {
+                        Warn warn = new Warn();
+                        long millis = sWarn.getDate();
+                        warn.setDate(new Date(millis));;
+                        Member warner = guild.getMemberById(sWarn.getWarner());
+                        warn.setWarner(warner);
+                        warn.setReason(sWarn.getReason());
+                        warns.add(warn);
+                    }
+            } catch (FileNotFoundException e) {
+                e.printStackTrace();
+            }
         }
         return warns;
     }
 
     public static boolean isMuted(Member m) {
-        boolean muted = false;
         File f = new File("users/" + m.getId() + "/mutes.yml");
-        if(f.exists()) {
-            YamlConfiguration c = YamlConfiguration.loadConfiguration(f);
-            muted = c.getBoolean("muted");
+        if (f.exists()) {
+            try {
+                SimpleMute sMute = (SimpleMute) ConfigUtils.deserialize("users/" + m.getId() + "/mutes.yml");
+                if (sMute != null && sMute.getMuted()) return true;
+            } catch (FileNotFoundException e) {
+                e.printStackTrace();
+            }
         }
-        return muted;
+        return false;
     }
 
     public static List<Mute> getMutes() {
         List<Mute> list = new ArrayList<>();
-        Bot.getBot().jda.getGuilds().stream().forEach((guild -> {
-            guild.getMembers().stream().forEach(m -> {
+        Bot.getBot().jda.getGuilds().forEach((guild -> {
+            guild.getMembers().forEach(m -> {
                 File f = new File("users/" + m.getId() + "/mutes.yml");
-                if(f.exists()) {
+                if (f.exists()) {
+                    /*
                     YamlConfiguration c = YamlConfiguration.loadConfiguration(f);
-                    if(c.getBoolean("muted")) {
+                    if (c.getBoolean("muted")) {
                         Mute mute = new Mute();
                         long time = c.getLong("expireDate");
                         mute.setDate(new Date(time));
@@ -241,6 +239,26 @@ public class Utils {
                             mute.setExpireDate(expireDate);
                         }
                         list.add(mute);
+
+                    }*/
+                    try {
+                        SimpleMute sMute = (SimpleMute) ConfigUtils.deserialize("users/" + m.getId() + "/mutes.yml");
+                        if(sMute != null && sMute.getMuted()) {
+                            Mute mute = new Mute();
+                            mute.setDate(new Date(sMute.getDate()));
+                            mute.setMember(guild.getMemberById(m.getId()));
+                            mute.setMuter(guild.getMemberById(sMute.getMuter()));
+                            mute.setReason(sMute.getReason());
+                            mute.setPermanent(sMute.getPermanent());
+                            mute.setType(MuteType.getType(sMute.getType()));
+                            if (!mute.isPermanent()) {
+                                Date expireDate = new Date(sMute.getExpireDate());
+                                mute.setExpireDate(expireDate);
+                            }
+                            list.add(mute);
+                        }
+                    } catch (FileNotFoundException e) {
+                        e.printStackTrace();
                     }
                 }
             });
@@ -252,50 +270,37 @@ public class Utils {
         Information info = new Information(m);
         info.setWarns(getWarns(m));
         info.setMuted(isMuted(m));
-        if(info.isMuted()) {
-
-            File f = new File("users/" + m.getId() + "/mutes.yml");
-
-            YamlConfiguration c = YamlConfiguration.loadConfiguration(f);
-
-            Mute mute = new Mute();
-            mute.setPermanent(c.getBoolean("permanent"));
-
-            if (!mute.isPermanent()) {
-                Date d = new Date(c.getLong("expireDate"));
-                mute.setExpireDate(d);
+        if (info.isMuted()) {
+            try {
+                SimpleMute simpleMute = (SimpleMute) ConfigUtils.deserialize("users/" + m.getId() + "/mutes.yml");
+                Mute mute = new Mute();
+                assert simpleMute != null;
+                mute.setPermanent(simpleMute.getPermanent());
+                if (!mute.isPermanent()) {
+                    Date d = new Date();
+                    mute.setExpireDate(d);
+                }
+                mute.setReason(simpleMute.getReason());
+                mute.setType(MuteType.getType(simpleMute.getType()));
+                mute.setMuted(info.isMuted());
+                mute.setDate(new Date(simpleMute.getDate()));
+                mute.setMuter(m.getGuild().getMemberById(simpleMute.getMuter()));
+                info.setMute(mute);
+            } catch (FileNotFoundException e) {
+                e.printStackTrace();
             }
-
-            mute.setReason(c.getString("reason"));
-            mute.setType(c.getString(("type")));
-            mute.setMuted(info.isMuted());
-            mute.setDate(new Date(c.getLong("date")));
-            /*List<Member> muter = new ArrayList<>();
-
-            Bot.getBot().jda.getGuilds().stream().forEach((guild -> {
-                guild.getMembers().stream().forEach((member -> {
-                    if(member.getId() == c.getString("muter")) {
-                        muter.clear();
-                        muter.add(member);
-                    }
-                }));
-            }));
-
-            mute.setMuter(muter.get(0));*/
-            mute.setMuter(m.getGuild().getMemberById(c.getString("muter")));
-            info.setMute(mute);
         }
         return info;
     }
 
     public static void unmute(Member m) {
         File f = new File("users/" + m.getId() + "/mutes.yml");
-        YamlConfiguration c = YamlConfiguration.loadConfiguration(f);
-        c.set("muted", false);
-        c.set("reason", null);
-        c.set("expireDate", null);
+        SimpleMute mute = new SimpleMute();
+        mute.setMuted(false);
+        mute.setReason(null);
+        mute.setExpireDate(-1);
         try {
-            c.save(f);
+            ConfigUtils.serialize(mute, "users/" + m.getId() + "/mutes.yml");
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/tests/de/demokratie/polizeibot/utils/ConfigUtilsTest.java
+++ b/src/tests/de/demokratie/polizeibot/utils/ConfigUtilsTest.java
@@ -1,0 +1,89 @@
+package de.demokratie.polizeibot.utils;
+
+import de.demokratie.polizeibot.objects.SimpleMute;
+import de.demokratie.polizeibot.objects.SimpleWarn;
+import de.demokratie.polizeibot.objects.SimpleWarnList;
+import de.demokratie.polizeibot.objects.Warn;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConfigUtilsTest {
+
+    @Test
+    void serialize() {
+        //Test for warns
+        SimpleWarn warn = new SimpleWarn();
+        warn.setDate(123L);
+        warn.setReason("TEST REASON");
+        warn.setWarner("TEST WARNER");
+        SimpleWarn warn2 = new SimpleWarn();
+        warn2.setDate(456L);
+        warn2.setReason("2TEST REASON");
+        warn2.setWarner("2TEST WARNER");
+        SimpleWarnList warnList = new SimpleWarnList();
+        List<SimpleWarn> warns = new ArrayList<>();
+        warns.add(warn);
+        warns.add(warn2);
+        warnList.setWarns(warns);
+        try {
+            ConfigUtils.serialize(warnList, "users/TestID-1/warns.yml");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        //Test for mute
+        SimpleMute mute = new SimpleMute();
+        mute.setDate(123L);
+        mute.setExpireDate(456L);
+        mute.setMember("TEST MEMBER");
+        mute.setMuted(true);
+        mute.setMuter("TEST MUTER");
+        mute.setPermanent(false);
+        mute.setType("TEST TYPE");
+        try {
+            ConfigUtils.serialize(mute, "users/TestID-1/mutes.yml");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    void deserialize() {
+        //Warns test
+        SimpleWarnList list = null;
+        try {
+            list = (SimpleWarnList) ConfigUtils.deserialize("users/TESTID-1/warns.yml");
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+        assertNotEquals(null, list);
+        if (list != null) {
+            for(SimpleWarn warn : list.getWarns()) {
+                System.out.println("-Date " + warn.getDate() + " -Reason " + warn.getReason() + " -Warner " + warn.getWarner());
+            }
+        }
+
+        //Mute test
+        SimpleMute mute = null;
+        try {
+            mute = (SimpleMute) ConfigUtils.deserialize("users/TESTID-1/mutes.yml");
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+        assertNotEquals(null, mute);
+        if (mute != null) {
+            assertEquals(123L, mute.getDate());
+            assertEquals("TEST MEMBER", mute.getMember());
+            assertEquals(456L, mute.getExpireDate());
+            assertEquals("TEST MUTER", mute.getMuter());
+            assertTrue(mute.getMuted());
+            assertFalse(mute.getPermanent());
+        }
+    }
+}


### PR DESCRIPTION
Removed Spigot API - switched to SnakeYaml
Added enum for MuteType
Added classes for serialization
Added Junit5 Test
Updated pom.xml

Ich schreibe mal auf Deutsch, geht schneller. Ich habe in erster Linie die Spigot-Configs entfernt und stattdessen SnakeYaml verwendet. SnakeYaml serialisiert Objecte in .yml Dateien. Dafür gibt es dann ein paar Klassen, welche alle mit "Simple" beginnen. Diese werden verwendet, damit SnakeYamel diese speichern kann.
Es gibt jedoch noch einen Fehler (den es von anfang an gab) und zwar werden TempMutes nicht gelöscht, es scheint als ob der Bot (so war es bei mir) nicht alle User findet, die online sind. Aber vielleicht war das auch nur bei mir das Problem.

MfG Blaumeise03